### PR TITLE
`WandbFileSystem.ls` fix when listing nested directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "wandbfsspec"
-version = "0.1.0"
+version = "0.1.1"
 packages = [
     { include = "wandbfsspec", from = "src" },
 ]

--- a/src/wandbfsspec/__init__.py
+++ b/src/wandbfsspec/__init__.py
@@ -4,4 +4,4 @@
 """`wandbfsspec `: fsspec interface for Weights & Biases (wandb)"""
 
 __author__ = "Alvaro Bartolome, alvarobartt @ GitHub"
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/src/wandbfsspec/core.py
+++ b/src/wandbfsspec/core.py
@@ -88,25 +88,23 @@ class WandbFileSystem(AbstractFileSystem):
         file_path = Path(file_path) if isinstance(file_path, str) else file_path
         files = []
         for _file in _files:
-            if file_path not in Path(_file.name).parents:
+            filename = Path(_file.name)
+            if file_path not in filename.parents:
                 continue
-            filename = Path(_file.name.replace(f"{file_path.as_posix()}/", ""))
-            if filename.is_dir() or len(filename.parents) > 1:
-                filename = filename.parent
-                if (
-                    any(f["name"] == f"{base_path}/{filename.name}" for f in files)
-                    if detail
-                    else f"{base_path}/{filename.name}" in files
-                ):
+            filename_strip = Path(_file.name.replace(f"{file_path}/", ""))
+            if filename_strip.is_dir() or len(filename_strip.parents) > 1:
+                filename_strip = filename_strip.parent.as_posix().split("/")[0]
+                path = f"{base_path}/{filename_strip}"
+                if any(f["name"] == path for f in files) if detail else path in files:
                     continue
                 files.append(
                     {
-                        "name": f"{base_path}/{filename.name}",
+                        "name": path,
                         "type": "directory",
                         "size": 0,
                     }
                     if detail
-                    else f"{base_path}/{filename.name}"
+                    else path
                 )
                 continue
             files.append(


### PR DESCRIPTION
This PR fixes https://github.com/alvarobartt/wandbfsspec/issues/7, as there was an issue when calling `WandbFileSystem.ls` over nested directories, as some of the intermediate directories were skipped and the produced path was a non-existing one.

The issue was taking place during the path strip, where it was not being properly stripped, so then when calculating the parents all the intermediate parents were not taken into consideration, just the top level file name.