### PR TITLE
Add file upload/download with dir/file rename in both ends

### DIFF
--- a/src/wandbfsspec/core.py
+++ b/src/wandbfsspec/core.py
@@ -194,6 +194,14 @@ class WandbFileSystem(AbstractFileSystem):
         file.delete()
 
     def cp_file(self, path1: str, path2: str, **kwargs) -> None:
+        path1_ext = os.path.splitext(path1)[1]
+        if path1_ext == "":
+            raise ValueError(f"Path {path1} must be a file path with extension!")
+        path2_ext = os.path.splitext(path2)[1]
+        if path2_ext == "":
+            raise ValueError(f"Path {path1} must be a file path with extension!")
+        if path1_ext != path2_ext:
+            raise ValueError("Path extensions must be the same for both parameters!")
         with tempfile.TemporaryDirectory() as f:
             self.get_file(lpath=f, rpath=path1, overwrite=True)
             _, _, _, file_path = self.split_path(path=path1)

--- a/src/wandbfsspec/core.py
+++ b/src/wandbfsspec/core.py
@@ -5,7 +5,6 @@ import datetime
 import os
 import tempfile
 import urllib.request
-import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Tuple, Union
 
@@ -171,12 +170,6 @@ class WandbFileSystem(AbstractFileSystem):
     def put_file(self, lpath: str, rpath: str, **kwargs) -> None:
         entity, project, run_id, file_path = self.split_path(path=rpath)
         run = self.api.run(f"{entity}/{project}/{run_id}")
-        warnings.warn(
-            "`rpath` should be a directory path not a file path, as in order to use"
-            " file paths we'll need to wait upon"
-            " https://github.com/wandb/client/pull/3929 merge",
-            RuntimeWarning,
-        )
         run.upload_file(path=lpath, root=file_path if file_path else ".")
 
     def get_file(
@@ -192,13 +185,6 @@ class WandbFileSystem(AbstractFileSystem):
         file.delete()
 
     def cp_file(self, path1: str, path2: str, **kwargs) -> None:
-        warnings.warn(
-            "`path2` should be a directory path not a file path, as in order to use"
-            " file paths we'll need to wait upon"
-            " https://github.com/wandb/client/pull/3924 merge",
-            RuntimeWarning,
-        )
-        # with tempfile.NamedTemporaryFile() as f: f.name
         with tempfile.TemporaryDirectory() as f:
             self.get_file(lpath=f, rpath=path1, overwrite=True)
             _, _, _, file_path = self.split_path(path=path1)


### PR DESCRIPTION
According to the following PRs created in [wandb](https://github.com/wandb/wandb), since those changes were not compliant with the main idea/intention behind the development of the Public API, we've decided now to move all those changes to [wandbfsspec](https://github.com/alvarobartt/wandbfsspec) so that we can use the Public API as always while allowing users to rename both the files and the directories on both ends, locally and in the remote.

- https://github.com/wandb/wandb/pull/3929
- https://github.com/wandb/wandb/pull/3924

⚠️ Note that this still needs to be properly unit tested and we need to make sure it's efficient!